### PR TITLE
Rename Tasklist references to NookPad and genericize paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Task List Instructions
+# NookPad Instructions
 
 ## GitHub Workflow
 - **Before starting any change**: Draft the issue title and body, then show it to the user for review and approval before creating it. The issue must be detailed enough to be worked on independently — include what is changing, why, and any relevant context or acceptance criteria.

--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -4,11 +4,13 @@ A live web dashboard that displays your tasks, shopping list, and ideas.
 
 ## Access
 
-Open in any browser on your local network:
+Open in any browser:
 
 ```
-http://192.168.50.11:6969
+http://localhost:6969
 ```
+
+To reach the dashboard from other devices on your LAN, replace `localhost` with the host machine's IP address (e.g. `http://192.168.1.42:6969`).
 
 The page auto-refreshes every 30 seconds.
 
@@ -28,7 +30,7 @@ The dashboard runs as a background service and starts automatically on boot.
 If you want to run the server directly in a terminal instead:
 
 ```
-python3 ~/documents/vibe-coding/tasklist/server.py
+python3 ~/NookPad/server.py
 ```
 
 Press `Ctrl+C` to stop it. If you get an "address already in use" error when restarting, kill the process still holding the port:
@@ -41,7 +43,7 @@ To keep it running after closing the terminal, use a tmux session:
 
 ```
 tmux new -s dashboard
-python3 ~/documents/vibe-coding/tasklist/server.py
+python3 ~/NookPad/server.py
 # Press Ctrl+B then D to detach
 ```
 
@@ -107,7 +109,7 @@ Each panel has a **+ Add** button in the header to add new entries without editi
 ## Installing the Service (first time setup)
 
 ```
-sudo cp ~/documents/vibe-coding/tasklist/dashboard.service /etc/systemd/system/
+sudo cp ~/NookPad/dashboard.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable dashboard
 sudo systemctl start dashboard

--- a/agents/WORKFLOW.md
+++ b/agents/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Agent Workflow
 
-This document describes the full lifecycle of an issue through the agent system for the `dvlprlife/vibe-coding` repository.
+This document describes the full lifecycle of an issue through the agent system for the `dvlprlife/NookPad` repository.
 
 ## Agents
 

--- a/agents/issue-planner.md
+++ b/agents/issue-planner.md
@@ -1,11 +1,11 @@
 # Issue Planner Agent
 
-You are an autonomous agent that reviews GitHub issues and writes implementation plans for the `dvlprlife/vibe-coding` repository.
+You are an autonomous agent that reviews GitHub issues and writes implementation plans for the `dvlprlife/NookPad` repository.
 
 ## Step 1: Find Eligible Issues
 
 ```
-gh issue list --repo dvlprlife/vibe-coding --label "agent" --label "status: need plan" --state open --json number,title,body,labels
+gh issue list --repo dvlprlife/NookPad --label "agent" --label "status: need plan" --state open --json number,title,body,labels
 ```
 
 If no issues are returned, report "No issues need planning." and stop.
@@ -15,7 +15,7 @@ If no issues are returned, report "No issues need planning." and stop.
 For the first eligible issue found:
 
 ```
-gh issue view {number} --repo dvlprlife/vibe-coding
+gh issue view {number} --repo dvlprlife/NookPad
 ```
 
 ## Step 3: Assess if a Plan Can Be Written
@@ -26,12 +26,12 @@ Determine if the issue body contains enough information to write a concrete impl
 
 1. Add `status: follow up` and `human` labels, remove `agent` label:
    ```
-   gh issue edit {number} --repo dvlprlife/vibe-coding --add-label "status: follow up" --add-label "human" --remove-label "agent"
+   gh issue edit {number} --repo dvlprlife/NookPad --add-label "status: follow up" --add-label "human" --remove-label "agent"
    ```
 
 2. Post a comment explaining what is missing:
    ```
-   gh issue comment {number} --repo dvlprlife/vibe-coding --body "## Needs Clarification
+   gh issue comment {number} --repo dvlprlife/NookPad --body "## Needs Clarification
 
    {explanation of what information is needed to write a plan}"
    ```
@@ -43,7 +43,7 @@ Determine if the issue body contains enough information to write a concrete impl
 ## Step 4: Post Implementation Plan Comment
 
 ```
-gh issue comment {number} --repo dvlprlife/vibe-coding --body "## Implementation Plan
+gh issue comment {number} --repo dvlprlife/NookPad --body "## Implementation Plan
 
 {bullet list of specific changes, file by file, with enough detail for the issue worker to execute}
 
@@ -57,7 +57,7 @@ gh issue comment {number} --repo dvlprlife/vibe-coding --body "## Implementation
 Remove `status: need plan` and add `status: ready` so the issue worker can pick it up:
 
 ```
-gh issue edit {number} --repo dvlprlife/vibe-coding --remove-label "status: need plan" --add-label "status: ready"
+gh issue edit {number} --repo dvlprlife/NookPad --remove-label "status: need plan" --add-label "status: ready"
 ```
 
 ## Rules

--- a/agents/issue-worker.md
+++ b/agents/issue-worker.md
@@ -1,12 +1,12 @@
 # Issue Worker Agent
 
-You are an autonomous agent that finds and works GitHub issues for the `dvlprlife/vibe-coding` repository.
+You are an autonomous agent that finds and works GitHub issues for the `dvlprlife/NookPad` repository.
 
 ## Step 1: Find Eligible Issues
 
 Run:
 ```
-gh issue list --repo dvlprlife/vibe-coding --label "agent" --label "status: ready" --state open --json number,title,body,labels
+gh issue list --repo dvlprlife/NookPad --label "agent" --label "status: ready" --state open --json number,title,body,labels
 ```
 
 If no issues are returned, report "No issues ready for agent processing." and stop.
@@ -17,24 +17,24 @@ For the first eligible issue found:
 
 1. **Mark it in-progress immediately** so no other agent picks it up:
    ```
-   gh issue edit {number} --repo dvlprlife/vibe-coding --add-label "status: in-progress" --remove-label "status: ready"
+   gh issue edit {number} --repo dvlprlife/NookPad --add-label "status: in-progress" --remove-label "status: ready"
    ```
 
 2. **Read the full issue** to understand exactly what needs to be done:
    ```
-   gh issue view {number} --repo dvlprlife/vibe-coding
+   gh issue view {number} --repo dvlprlife/NookPad
    ```
 
 ## Step 3: Verify an Implementation Plan Exists
 
 Check that an "## Implementation Plan" comment already exists on the issue:
 ```
-gh issue view {number} --repo dvlprlife/vibe-coding --comments
+gh issue view {number} --repo dvlprlife/NookPad --comments
 ```
 
 If **no Implementation Plan comment is found**: transition the issue back to `status: need plan` and stop:
 ```
-gh issue edit {number} --repo dvlprlife/vibe-coding --remove-label "status: in-progress" --add-label "status: need plan"
+gh issue edit {number} --repo dvlprlife/NookPad --remove-label "status: in-progress" --add-label "status: need plan"
 ```
 
 If a plan comment exists: proceed.
@@ -77,7 +77,7 @@ git push -u origin issue-{number}-short-description
 ## Step 7: Open a PR
 
 ```
-gh pr create --repo dvlprlife/vibe-coding \
+gh pr create --repo dvlprlife/NookPad \
   --title "{issue title}" \
   --body "## Summary
 {brief description of what was changed}
@@ -89,14 +89,14 @@ Closes #{number}"
 
 After the PR is opened, update the issue label to reflect it is awaiting human review:
 ```
-gh issue edit {number} --repo dvlprlife/vibe-coding --add-label "status: in-review" --remove-label "status: in-progress"
+gh issue edit {number} --repo dvlprlife/NookPad --add-label "status: in-review" --remove-label "status: in-progress"
 ```
 
 ## Step 9: Comment on the Issue
 
 Post a comment linking to the PR so the issue is traceable:
 ```
-gh issue comment {number} --repo dvlprlife/vibe-coding --body "PR opened: {pr_url}"
+gh issue comment {number} --repo dvlprlife/NookPad --body "PR opened: {pr_url}"
 ```
 
 ## Rules

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,11 +1,11 @@
 # PR Reviewer Agent
 
-You are an autonomous agent that reviews open pull requests for the `dvlprlife/vibe-coding` repository. You check each PR against the Implementation Plan, the issue's Acceptance Criteria, code quality, and CLAUDE.md compliance, then report findings on both the PR and the linked issue.
+You are an autonomous agent that reviews open pull requests for the `dvlprlife/NookPad` repository. You check each PR against the Implementation Plan, the issue's Acceptance Criteria, code quality, and CLAUDE.md compliance, then report findings on both the PR and the linked issue.
 
 ## Step 1: Find Eligible Issues
 
 ```
-gh issue list --repo dvlprlife/vibe-coding --label "agent" --label "status: in-review" --state open --json number,title,body
+gh issue list --repo dvlprlife/NookPad --label "agent" --label "status: in-review" --state open --json number,title,body
 ```
 
 If no issues are returned, report "No PRs awaiting review." and stop.
@@ -15,13 +15,13 @@ If no issues are returned, report "No PRs awaiting review." and stop.
 For the first eligible issue:
 
 ```
-gh pr list --repo dvlprlife/vibe-coding --state open --search "Closes #{number} in:body" --json number,url,headRefName,author
+gh pr list --repo dvlprlife/NookPad --state open --search "Closes #{number} in:body" --json number,url,headRefName,author
 ```
 
 If no PR is found, post a note on the issue and skip to the next eligible issue (do not invent a PR):
 
 ```
-gh issue comment {number} --repo dvlprlife/vibe-coding --body "## Review Skipped
+gh issue comment {number} --repo dvlprlife/NookPad --body "## Review Skipped
 
 No open PR references this issue with \`Closes #{number}\`. Re-check once the worker opens the PR."
 ```
@@ -31,9 +31,9 @@ No open PR references this issue with \`Closes #{number}\`. Re-check once the wo
 Pull everything needed to compare the PR against the plan and the issue:
 
 ```
-gh issue view {issue_number} --repo dvlprlife/vibe-coding --comments
-gh pr view {pr_number} --repo dvlprlife/vibe-coding
-gh pr diff {pr_number} --repo dvlprlife/vibe-coding
+gh issue view {issue_number} --repo dvlprlife/NookPad --comments
+gh pr view {pr_number} --repo dvlprlife/NookPad
+gh pr diff {pr_number} --repo dvlprlife/NookPad
 ```
 
 From the issue, extract:
@@ -52,7 +52,7 @@ From the issue, extract:
 **If findings exist:** request changes. Fall back to a comment review if GitHub blocks `--request-changes` (e.g. same-author PRs):
 
 ```
-gh pr review {pr_number} --repo dvlprlife/vibe-coding --request-changes --body "## Automated Review
+gh pr review {pr_number} --repo dvlprlife/NookPad --request-changes --body "## Automated Review
 
 ### Findings
 {bulleted list of issues, each labeled by category: Plan / AC / Quality / CLAUDE.md, citing file paths and line numbers}
@@ -64,13 +64,13 @@ gh pr review {pr_number} --repo dvlprlife/vibe-coding --request-changes --body "
 If `--request-changes` fails:
 
 ```
-gh pr review {pr_number} --repo dvlprlife/vibe-coding --comment --body "..."
+gh pr review {pr_number} --repo dvlprlife/NookPad --comment --body "..."
 ```
 
 **If the PR looks good:** post a comment review (agents cannot self-approve):
 
 ```
-gh pr review {pr_number} --repo dvlprlife/vibe-coding --comment --body "## Automated Review
+gh pr review {pr_number} --repo dvlprlife/NookPad --comment --body "## Automated Review
 
 All four criteria satisfied:
 - Plan adherence: ✓
@@ -84,7 +84,7 @@ Ready for human approval."
 ## Step 6: Summarize on the Issue
 
 ```
-gh issue comment {issue_number} --repo dvlprlife/vibe-coding --body "## Review Summary
+gh issue comment {issue_number} --repo dvlprlife/NookPad --body "## Review Summary
 
 PR: {pr_url}
 
@@ -96,13 +96,13 @@ PR: {pr_url}
 **If findings were posted:** add `status: follow up` and `human`, remove `status: in-review`:
 
 ```
-gh issue edit {issue_number} --repo dvlprlife/vibe-coding --add-label "status: follow up" --add-label "human" --remove-label "status: in-review"
+gh issue edit {issue_number} --repo dvlprlife/NookPad --add-label "status: follow up" --add-label "human" --remove-label "status: in-review"
 ```
 
 **If the PR was clean:** add `status: agent approved`, remove `status: in-review`:
 
 ```
-gh issue edit {issue_number} --repo dvlprlife/vibe-coding --add-label "status: agent approved" --remove-label "status: in-review"
+gh issue edit {issue_number} --repo dvlprlife/NookPad --add-label "status: agent approved" --remove-label "status: in-review"
 ```
 
 ## Rules

--- a/agents/repo-check.md
+++ b/agents/repo-check.md
@@ -1,11 +1,11 @@
 # Repo Check Agent
 
-You are an agent that ensures all required GitHub labels exist in the `dvlprlife/vibe-coding` repository.
+You are an agent that ensures all required GitHub labels exist in the `dvlprlife/NookPad` repository.
 
 ## Step 1: List Existing Labels
 
 ```
-gh label list --repo dvlprlife/vibe-coding --json name --limit 100
+gh label list --repo dvlprlife/NookPad --json name --limit 100
 ```
 
 ## Step 2: Check and Create Required Labels
@@ -14,14 +14,14 @@ For each label in the list below, check if it exists in the output from Step 1. 
 
 | Label | Color | Description | Create command |
 |-------|-------|-------------|----------------|
-| `agent` | `#0075ca` | Issue is assigned to an agent for automated processing | `gh label create "agent" --repo dvlprlife/vibe-coding --color "0075ca" --description "Issue is assigned to an agent for automated processing"` |
-| `status: ready` | `#0e8a16` | Issue is ready to be picked up | `gh label create "status: ready" --repo dvlprlife/vibe-coding --color "0e8a16" --description "Issue is ready to be picked up"` |
-| `status: in-progress` | `#e4e669` | Issue is currently being worked on | `gh label create "status: in-progress" --repo dvlprlife/vibe-coding --color "e4e669" --description "Issue is currently being worked on"` |
-| `status: in-review` | `#d93f0b` | Issue has an open PR awaiting review | `gh label create "status: in-review" --repo dvlprlife/vibe-coding --color "d93f0b" --description "Issue has an open PR awaiting review"` |
-| `status: follow up` | `#c5def5` | Needs follow-up after completion | `gh label create "status: follow up" --repo dvlprlife/vibe-coding --color "c5def5" --description "Needs follow-up after completion"` |
-| `human` | `#b60205` | Requires human attention or intervention | `gh label create "human" --repo dvlprlife/vibe-coding --color "b60205" --description "Requires human attention or intervention"` |
-| `status: need plan` | `#fbca04` | Issue needs a plan before work can begin | `gh label create "status: need plan" --repo dvlprlife/vibe-coding --color "fbca04" --description "Issue needs a plan before work can begin"` |
-| `status: agent approved` | `#2da44e` | PR reviewer agent found no issues; awaiting human approval | `gh label create "status: agent approved" --repo dvlprlife/vibe-coding --color "2da44e" --description "PR reviewer agent found no issues; awaiting human approval"` |
+| `agent` | `#0075ca` | Issue is assigned to an agent for automated processing | `gh label create "agent" --repo dvlprlife/NookPad --color "0075ca" --description "Issue is assigned to an agent for automated processing"` |
+| `status: ready` | `#0e8a16` | Issue is ready to be picked up | `gh label create "status: ready" --repo dvlprlife/NookPad --color "0e8a16" --description "Issue is ready to be picked up"` |
+| `status: in-progress` | `#e4e669` | Issue is currently being worked on | `gh label create "status: in-progress" --repo dvlprlife/NookPad --color "e4e669" --description "Issue is currently being worked on"` |
+| `status: in-review` | `#d93f0b` | Issue has an open PR awaiting review | `gh label create "status: in-review" --repo dvlprlife/NookPad --color "d93f0b" --description "Issue has an open PR awaiting review"` |
+| `status: follow up` | `#c5def5` | Needs follow-up after completion | `gh label create "status: follow up" --repo dvlprlife/NookPad --color "c5def5" --description "Needs follow-up after completion"` |
+| `human` | `#b60205` | Requires human attention or intervention | `gh label create "human" --repo dvlprlife/NookPad --color "b60205" --description "Requires human attention or intervention"` |
+| `status: need plan` | `#fbca04` | Issue needs a plan before work can begin | `gh label create "status: need plan" --repo dvlprlife/NookPad --color "fbca04" --description "Issue needs a plan before work can begin"` |
+| `status: agent approved` | `#2da44e` | PR reviewer agent found no issues; awaiting human approval | `gh label create "status: agent approved" --repo dvlprlife/NookPad --color "2da44e" --description "PR reviewer agent found no issues; awaiting human approval"` |
 
 ## Step 3: Report Results
 

--- a/dashboard.service
+++ b/dashboard.service
@@ -1,12 +1,14 @@
+# Replace USERNAME with your Linux user (the same value used for User= below).
+# Assumes the repo is cloned to /home/USERNAME/NookPad.
 [Unit]
-Description=Tasklist Dashboard
+Description=NookPad Dashboard
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python3 /home/brad/documents/vibe-coding/tasklist/server.py
-WorkingDirectory=/home/brad/documents/vibe-coding/tasklist
+ExecStart=/usr/bin/python3 /home/USERNAME/NookPad/server.py
+WorkingDirectory=/home/USERNAME/NookPad
 Restart=always
-User=brad
+User=USERNAME
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Renames `Tasklist` → `NookPad` in the systemd unit description and `CLAUDE.md` top-level heading.
- Replaces author-specific paths (`/home/brad/documents/vibe-coding/tasklist/`) with `~/NookPad/` in `DASHBOARD.md` and a `/home/USERNAME/NookPad/` placeholder (plus a comment) in `dashboard.service`.
- Replaces the hardcoded LAN IP in `DASHBOARD.md` with `http://localhost:6969` and a note that the device IP can be substituted to reach the dashboard from other devices on the LAN.
- Updates the agent definitions under `agents/` from `dvlprlife/vibe-coding` to `dvlprlife/NookPad` so the workflow agents target the new repo.

Closes #1

## Test plan
- [ ] `grep -rE "Tasklist|/home/brad|vibe-coding|192\\.168\\.50\\.11" .` returns no results (already verified locally).
- [ ] `DASHBOARD.md` instructions are followable by a new user who clones the repo into `~/NookPad`.
- [ ] `dashboard.service` installs cleanly after the user substitutes their Linux username for `USERNAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)