### PR TITLE
Match ideas-panel category-group header coloring to the tasks panel

### DIFF
--- a/server.py
+++ b/server.py
@@ -1724,7 +1724,6 @@ tr.cat-header:hover td { background: #1e4a7a; color: #e0f2fe; }
 .cat-caret { display: inline-block; width: 0.9rem; color: #7dd3fc; font-size: 0.7rem; }
 .cat-count { color: #64748b; font-size: 0.7rem; margin-left: 0.35rem; font-weight: 500; text-transform: none; }
 tbody.cat-group.collapsed tr:not(.cat-header) { display: none; }
-.idea-cat-group { margin-bottom: 0.6rem; }
 .idea-cat-group h3.cat-header {
     background: #0f2942;
     color: #7dd3fc;
@@ -1733,6 +1732,7 @@ tbody.cat-group.collapsed tr:not(.cat-header) { display: none; }
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding: 0.4rem 0.6rem;
+    margin: 0;
     cursor: pointer;
     user-select: none;
     border-bottom: 1px solid #1e4a7a;


### PR DESCRIPTION
## Summary
Two-line CSS fix to the `.idea-cat-group` rules at `server.py:1727-1741`:

1. **Added `margin: 0;`** to `.idea-cat-group h3.cat-header`. The global `.card h3 { margin: 1rem 0 0.4rem }` rule was leaking through (only specificity-overridden properties were being beaten — `margin` wasn't declared in the new rule), creating vertical gaps and shrinking the painted strip. With `margin: 0` the strip paints flush like the tasks `<tr class="cat-header">`.
2. **Removed `.idea-cat-group { margin-bottom: 0.6rem }`** so consecutive category groups stack flush (matches the tasks `<tbody class="cat-group">` stacking; the header's `border-bottom: 1px solid #1e4a7a` is the only separator).

No new color values, no markup change, no shared-class refactor. The colors were already correct — they were just being painted on a strip that was the wrong size and position.

## Test plan
- [x] `.card h3` rule at `server.py:1497` unchanged — agenda/cheatsheet/modal `<h3>` elements still get the muted-gray treatment (specificity rules still favor `.idea-cat-group h3.cat-header` only for the ideas panel)
- [x] `ideas_html()` still emits the same `<h3 class="cat-header">` markup — only CSS changed
- [ ] Browser visual check: ideas-panel and tasks-panel header strips look identical (background, hover, padding, border, count chip, caret); toggle a few groups in each panel to confirm caret flip matches
- [ ] Browser visual check: tasks panel header strip unchanged (the rule it relies on, `tr.cat-header td`, was untouched)

Closes #34