### PR TITLE
Pause dashboard auto-refresh while a modal is open

### DIFF
--- a/server.py
+++ b/server.py
@@ -1885,7 +1885,6 @@ def dashboard_page():
   <title>NookPad</title>
   <link rel="stylesheet" href="/style.css">
   {FAVICON_LINK}
-  <meta http-equiv="refresh" content="30">
 </head>
 <body>
   <header>
@@ -1898,6 +1897,18 @@ def dashboard_page():
     {ideas_html()}
     {shopping_html()}
   </div>
+  <script>
+    (function() {{
+      function tick() {{
+        if (document.querySelector('.modal-overlay.open')) {{
+          setTimeout(tick, 2000);
+        }} else {{
+          window.location.reload();
+        }}
+      }}
+      setTimeout(tick, 30000);
+    }})();
+  </script>
 </body>
 </html>"""
 


### PR DESCRIPTION
## Summary
- Replace the 30s `<meta http-equiv="refresh">` on the main dashboard with a JS timer that checks for `.modal-overlay.open` before reloading.
- If any modal is open when the timer fires, the reload is deferred and re-checks every 2s until the modal is closed.

Closes #40

## Test plan
- [ ] Load `/`, wait 30s with no modal open — page reloads.
- [ ] Open Add Task modal, wait >30s, confirm modal stays open and input is preserved.
- [ ] Close the modal — page reloads shortly after (within ~2s).
- [ ] Repeat for Edit Task, Add Idea, Edit Idea, Promote Idea, and Add Shopping modals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)